### PR TITLE
Добавляет глагол для вывода подтипов

### DIFF
--- a/russian/_verbs_ru.dm
+++ b/russian/_verbs_ru.dm
@@ -52,4 +52,33 @@
 	if(holder)
 		// verbs += /client/proc/edit_cases_ru // TODO CODE A PROPER EDITOR
 		verbs += /client/proc/debug_cases_ru
+		verbs += /client/proc/type2txt_ru
 	..()
+
+// the following is a helpful proc that lists out all the name vars of subtypes in a given typepath
+// the intended application is to see what types within modules aren't localized yet
+/client/proc/type2txt_ru()
+	set name = "Вывести названия подтипов"
+	set category = "Дебаг"
+	var/typepath = tgui_input_text(usr, "Введите тип:", "Вывести названия подтипов")
+	if(!typepath || ispath(typepath)) return
+	var/list/types = typesof(typepath)
+	var/dat = "<meta charset=\"UTF-8\">Подтипы [typepath]:<HR>"
+	dat += "<body><table border=1 cellspacing=5><B><tr><th>Название</th><th>Тип</th><th>Шаблон</th><th>Род</th><th>И.П</th><th>Р.П</th><th>Д.П</th><th>В.П</th><th>Т.П</th><th>П.П</th><th>number_lock</th><th>always_plural</th></tr></B>"
+	for(var/path in types)
+		var/atom/item = new path
+		dat += "<tr><td>[item]</td>" // имя
+		dat += "<td>[item.type]</td>" // тип
+		dat += "<td>[item.case_blueprint_ru? item.case_blueprint_ru[1] : "<b><span style='color: red;'>НЕТ</span></b>"]</td>" // шаблон
+		dat += "<td>[item.cases_ru["rugender"]? item.cases_ru["rugender"] : "Нет"]</td>"
+		dat += "<td>[ncase_ru(item)]</td>" // и.п
+		dat += "<td>[gcase_ru(item)]</td>" // р.п
+		dat += "<td>[dcase_ru(item)]</td>" // д.п
+		dat += "<td>[acase_ru(item)]</td>" // в.п
+		dat += "<td>[icase_ru(item)]</td>" // т.п
+		dat += "<td>[pcase_ru(item)]</td>" // п.п
+		dat += "<td>[item.number_lock_ru? number_lock_ru : "Нет"]</td>" // число
+		dat += "<td>[item.always_plural_ru? always_plural_ru : "Нет"]</td></tr>" // мн. ч
+		qdel(item)
+	dat += "</table></body></html>"
+	src << browse(dat,"window=src.type")


### PR DESCRIPTION
Добавляет во вкладку Дебаг глагол для вывода подтипов заданного типа с целью дебага локализации.
Способ исключить спавн атома и его qdel, возможно, где-то и существует, но мне настолько много платят, чтобы у меня было желание в этом копаться.
![image](https://user-images.githubusercontent.com/71944276/199933335-763bd3a7-f795-4b88-a031-67adb6c023eb.png)
![image](https://user-images.githubusercontent.com/71944276/199933360-7c2912f9-5059-48d8-83f2-b9f61cc46650.png)
