### PR TITLE
Рефакторит лист падежей в подлисты

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -206,7 +206,8 @@ SUBSYSTEM_DEF(supply)
 		var/obj/A = new SP.containertype(pickedloc)
 		A.name = "[SP.containername] [SO.comment ? "([SO.comment])":"" ]"
 		// Bastion of Endeavor Addition: Give the container itself some cases for grammatical polish, those are defined in supply pack datums
-		A.assigncases_ru(SP.cases_ru["containername"])
+		// Bastion of Endeavor TODO: I can't be bothered to test if this works after one of our 20231234534 case system refactors but come back to this when cargo is localized ig
+		A.cases_ru = deepCopyList(SP.cases_ru["containername"])
 		// End of Bastion of Endeavor Addition	
 
 		//supply manifest generation begin

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -511,10 +511,10 @@ var/global/datum/controller/subsystem/ticker/ticker
 	var/captainless=1
 	for(var/mob/living/carbon/human/player in player_list)
 		if(player && player.mind && player.mind.assigned_role)
-			/* Bastion of Endeavor Translation: Bastion of Endeavor TODO: Again, I'll leave this for now, because depending on how we go about localizing job datums the names might remain unlocalized
+			/* Bastion of Endeavor Translation
 			if(player.mind.assigned_role == "Site Manager")
 			*/
-			if(player.mind.assigned_role == "Site Manager")
+			if(player.mind.assigned_role == "Менеджер объекта")
 			// End of Bastion of Endeavor Translation
 				captainless=0
 			if(!player_is_antag(player.mind, only_offstation_roles = 1))

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -264,7 +264,6 @@ var/global/datum/ErrorViewer/ErrorCache/error_cache = null
 			*/
 			html += "<br>src.loc: <a href='?_src_=vars;Vars=\ref[srcLoc]'>ПП</a>"
 			html += " <a href='?_src_=holder;adminplayerobservecoodjump=1;X=[srcLoc.x];Y=[srcLoc.y];Z=[srcLoc.z]'>Прыгнуть</a>"
-			case_blueprint_ru = list("")
 			// End of Bastion of Endeavor Translation
 	if(usrRef)
 		/* Bastion of Endeavor Translation

--- a/russian/_cases_revamped_ru.dm
+++ b/russian/_cases_revamped_ru.dm
@@ -1,8 +1,10 @@
 // Weird grammar bullshit goes here
+var/global/list/successful_cases_ru = list()
+
 /atom/New() // radical? yes. will it break things? won't know until we try.
 	..()
 	cases_ru = new /list()
-	create_cases_ru()
+	create_cases_ru("basic")
 	construct_cases_ru()
 
 /datum/proc/create_cases_ru(var/subcase)
@@ -13,6 +15,8 @@
 		cases_ru.Add(basic_cases_list_ru)
 
 /datum/proc/construct_cases_ru()
+	var/enable_logging = FALSE
+	var/enable_reporting = FALSE
 	if(isnull(case_blueprint_ru)) 	// if we're lacking a blueprint then it's probably unlocalized
 		return						// so don't bother with it
 	if(!(islist(case_blueprint_ru)))
@@ -21,7 +25,7 @@
 		return
 	else if (case_blueprint_ru.len == 0)
 		return
-	//log_grammar_ru("Производится сборка падежей для [src.type].")
+	if(enable_logging) log_grammar_ru("Производится сборка падежей для [src.type].")
 	// муж#безымянн;1a подарок&подарк;3*a для проверки системы падежей
 	var/list/returning_case_list = new /list()														// what we're going to be outputting, basically
 	for(var/current_blueprint=1, current_blueprint<=case_blueprint_ru.len, current_blueprint++)		// so for every template in the list we are provided with
@@ -34,7 +38,7 @@
 			log_grammar_ru("ВНИМАНИЕ: шаблон [src.type] содержит более двух разделителей: [case_blueprint_ru[current_blueprint]]")
 			warning("Шаблон [src.type] содержит более двух разделителей: [case_blueprint_ru[current_blueprint]]")
 		// working_blueprint = "муж", "безымянн;adj1a подарок&подарк;n3*a для проверки системы падежей", ""
-		//log_grammar_ru("working_blueprint типа [src.type]: [working_blueprint.Join(", ")]")
+		if(enable_logging) log_grammar_ru("working_blueprint: [working_blueprint.Join(", ")]")
 		// let's store them here for now. makes the proc look a little less ugly
 		var/list/template_list = list(RUGENDER = shortrugender2gender_ru(working_blueprint[1]), "wordbase" = working_blueprint[2])
 		var/list/casekey_helper = list("casekey" = "")
@@ -42,25 +46,25 @@
 			casekey_helper["casekey"] = working_blueprint[3]
 			template_list.Add(casekey_helper)
 		//template_list = "male", "безымянн;adj1a подарок&подарк;n3*a для проверки системы падежей", ""
-		//log_grammar_ru("template_list типа [src.type]: [template_list.Join(", ")]")
+		if(enable_logging) log_grammar_ru("template_list: [jointext(list_values(template_list), ", ")]")
 		var/list/temp_cases_list = list(NCASE = "", GCASE = "", DCASE = "", ACASE = "", ICASE = "", PCASE = "", PLURAL_NCASE = "", PLURAL_GCASE = "", PLURAL_DCASE = "", PLURAL_ACASE = "", PLURAL_ICASE = "", PLURAL_PCASE = "") // our list of 6 basic grammar cases
 		var/list/word_list = splittext_char(template_list["wordbase"], " ")								// now, let's break down the rest and separate the words
 		// word_list = "безымянн;1a", "подарок&подарк;3*a", "для", "проверки", "падежей"
-		//log_grammar_ru("word_list типа [src.type]: [word_list.Join(", ")]")
+		if(enable_logging) log_grammar_ru("word_list: [word_list.Join(", ")]")
 		for(var/j=1, j<=word_list.len, j++)												// alright, so for every word that we have in wordbase
-			//log_grammar_ru("[word_list[j]]")
+			if(enable_logging) log_grammar_ru("Сборка окончаний для word_list [j]: [word_list[j]]")
 			if(findtext_char(word_list[j], ";"))										// if the word contains a ; that defines our word ending
 				var/list/constructor_list = splittext_char(word_list[j], ";")			// then take it apart and store it in a list
 				// constructor_list = 1) "безымянн", "adj1a" 2) "подарок&подарк", "n3*a"
 				// what the next line does is creating a key that finds us a list of endings the word is supposed to use
-				//log_grammar_ru("constructor_list типа [src.type]: [constructor_list.Join(", ")]")
+				if(enable_logging) log_grammar_ru("constructor_list: [constructor_list.Join(", ")]")
 				var/endings_key = "[template_list[RUGENDER]]_[constructor_list[2]]"
 				if(case_repository_ru.Find(endings_key))
 					var/string_to_fill = strip_accent_ru(case_repository_ru[endings_key])
 					// string_to_fill = 1) ??? 2) "{{{основа}}};{{{основа1}}}а;{{{основа1}}}у;{{{основа}}};{{{основа1}}}ом;{{{основа1}}}е;{{{основа1}}}и;{{{основа1}}}ов;{{{основа1}}}ам;{{{основа1}}}и;{{{основа1}}}ами;{{{основа1}}}ах"
 					var/list/word_bases_list = splittext_char(constructor_list[1], "&")
 					// word_bases_list 1) "безымянн" 2) "подарок", "подарк"
-					//log_grammar_ru("word_bases_list типа [src.type]: [word_bases_list.Join(", ")]")
+					if(enable_logging) log_grammar_ru("word_bases_list: [word_bases_list.Join(", ")]")
 					if(word_bases_list.len == 1)
 						// not using regex here because it straight up doesnt work with unicode
 						string_to_fill = replacetext_char(string_to_fill, "{{{основа}}}", word_bases_list[1])
@@ -70,47 +74,50 @@
 						string_to_fill = replacetext_char(string_to_fill, "{{{основа4}}}", word_bases_list[1])
 						string_to_fill = replacetext_char(string_to_fill, "{{{основа5}}}", word_bases_list[1])
 						//string_to_fill = replacetext_char(string_to_fill, regex("(\\{\\{\\{основ.*\\}\\}\\})", "g"), word_bases_list[1])
-						//log_grammar_ru("string_to_fill типа [src.type]: [string_to_fill]")
+						if(enable_logging) log_grammar_ru("string_to_fill: [string_to_fill]")
 					else
 						var/z = 0
 						for(var/word_base in word_bases_list)
 							var/string_to_replace = "{{{основа[z==0? "" : z]}}}"
 							string_to_fill = replacetext_char(string_to_fill, string_to_replace, "[word_bases_list[z+1]]")
 							z++
-						//log_grammar_ru("string_to_fill типа [src.type]: [string_to_fill]")
+						if(enable_logging) log_grammar_ru("string_to_fill: [string_to_fill]")
 					// string_to_fill = "подарок;подарка;подарку;подарок;подарком;подарке;подарки;подарков;подаркам;подарки;подарками;подарках"
 					var/list/complete_word_list = splittext_char(string_to_fill, ";")
-					//log_grammar_ru("complete_word_list типа [src.type]: [complete_word_list.Join(", ")]")
+					if(enable_logging) log_grammar_ru("complete_word_list: [complete_word_list.Join(", ")]")
 					var/i = 0															// the reason im not using i in the for loop itself is that
 					for(var/case in temp_cases_list)									// we want to refer to the case by its name
-						//log_grammar_ru("Собираем падеж [case] типа [src.type].")
 						i++																// but we also want a counting var
 						// so for instance, temp_cases_list[GCASE] += "загадочн"+"ого"+""
 						temp_cases_list[case] += "[complete_word_list[i]][j == word_list.len? "" : " "]"
+						// commenting this one out because takes too much space
+						// if(enable_logging) log_grammar_ru("Собираем падеж [case]: [temp_cases_list[case]]")
 				else
-					log_grammar_ru("ОШИБКА: Ключ [endings_key] не найден. Шаблон [case_blueprint_ru[current_blueprint]] типа [src.type].")
-					error("Ключ [endings_key] не найден. Шаблон [case_blueprint_ru[current_blueprint]] типа [src.type].")
+					log_grammar_ru("ОШИБКА: Ключ [endings_key] не найден. Шаблон [case_blueprint_ru[current_blueprint]].")
+					error("Ключ [endings_key] не найден. Шаблон [case_blueprint_ru[current_blueprint]].")
 					continue
 			else																			// if the word doesn't contain a ;
 				for(var/case_extra in temp_cases_list)											// then for every case it has
 					temp_cases_list[case_extra] += "[word_list[j]][j == word_list.len? "" : " "]"	// just slap the word in and call it a day
-		//log_grammar_ru("temp_cases_list типа [src.type]: [temp_cases_list.Join(", ")]")
+		if(enable_logging) log_grammar_ru("temp_cases_list: [jointext(list_values(temp_cases_list), ", ")]")
 		var/list/final_cases_list = list(RUGENDER = template_list[RUGENDER], PLURAL_RUGENDER = "plural")		// now just toss the rugender in
 		final_cases_list.Add(temp_cases_list)											// and compile it into a final list
-		//log_grammar_ru("final_case_list типа [src.type]: [final_cases_list.Join(", ")]")
-		if(length_char(template_list["casekey"])>1)										// and if we happen to have a case key,
+		if(enable_logging) log_grammar_ru("final_cases_list: [jointext(list_values(final_cases_list), ", ")]")
+		if(!isnull(template_list["casekey"]))									// and if we happen to have a case key,
 			returning_case_list[template_list["casekey"]] = final_cases_list			// then make into a nested list
-		else																			// otherwise,
-			returning_case_list = final_cases_list										// just dump the final list into the returning list
-			//log_grammar_ru("returning_case_list типа [src.type]: [returning_case_list.Join(", ")]")
-	src.assigncases_ru(returning_case_list)												// all that's left is to deepcopy the list into the datum's case_ru var
-	//log_grammar_ru(cases_ru.Join(", "))
-	/*if(successful_cases_ru.Find(src.type))
+		else
+			returning_case_list["basic"] = final_cases_list
+		if(enable_logging) log_grammar_ru("returning_case_list: [returning_case_list.Join(", ")]")
+	src.cases_ru = deepCopyList(returning_case_list)											// all that's left is to deepcopy the list into the datum's case_ru var
+	
+	if(enable_logging)
+		for(var/case_group in cases_ru)
+			log_grammar_ru("[case_group]: [jointext(list_values(cases_ru[case_group]), ", ")]")
+	if(successful_cases_ru.Find(src.type))
 		return
 	else
 		successful_cases_ru += src.type
-		log_grammar_ru("Завершена сборка падежей [case_ru(src, GCASE)] (тип [src.type], в.п. [case_ru(src, ACASE)])")
-	*/
+		if(enable_reporting) log_grammar_ru("Завершена сборка падежей [case_ru(src, GCASE)] (тип [src.type], в.п. [case_ru(src, ACASE)])")
 
 /proc/shortrugender2gender_ru(var/rugender)
 	switch(lowertext(rugender))

--- a/russian/_cases_ru.dm
+++ b/russian/_cases_ru.dm
@@ -16,14 +16,16 @@ var/global/list/self_cases_list_ru = list(
 	ICASE = "собой", \
 	PCASE = "себе")
 /datum
-	var/list/case_blueprint_ru
-	var/list/cases_ru
+	var/list/case_blueprint_ru = list()
+	var/list/cases_ru = list()
 	var/number_lock_ru
 	var/always_plural_ru
 
 // This is one of the core procs. It handles the grammar cases of words and uses them in messages. Secondary is for "subtype" cases.
 // input - the atom we're getting the form for, case - the case in question, secondary is needed for nested case lists, force_mode gets singular/plural forms, self_check is the user that interacts with the input
 /proc/case_ru(atom/input, case = "case", self_check = null, secondary = null, force_mode="normal")
+	if(!input)
+		return
 	if(input == self_check)
 		if(case == NCASE) // I can't think of a situation where this happens, but if it does, something is seriously fucked.
 			log_grammar_ru("ОШИБКА: self_check с именительным падежом! Ввод: [input]")
@@ -46,13 +48,9 @@ var/global/list/self_cases_list_ru = list(
 	return input.name
 
 /proc/return_case_ru(atom/input, case = "case", secondary)
-	if(secondary)
-		if(input.cases_ru[secondary][case])
-			return input.cases_ru[secondary][case]
-	else
-		if(input.cases_ru[case])
-			return input.cases_ru[case]
-		return input.name
+	if(!secondary) secondary = "basic"
+	if(input.cases_ru[secondary][case])
+		return input.cases_ru[secondary][case]
 	return input.name
 
 // A more faithful version of BYOND's capitalize() proc.
@@ -79,24 +77,3 @@ var/global/list/self_cases_list_ru = list(
 /proc/pcase_ru(var/input, var/user, var/secondary = null, var/force_mode="normal")
 	return case_ru(input, PCASE, user, secondary, force_mode)
 
-// Largely a copypaste of verb_adv_ru with the target removed. Meant to be used in the procs below.
-/proc/verb_ru(var/atom/verb_user, var/input)
-	var/list/message_list = splittext_char(input, ";")
-	if(message_list.len == 1)
-		return "[gender_ru(verb_user, input)]" // If the template is omitted, use the default verb endings.
-	if(message_list.len < 5)
-		log_grammar_ru("ОШИБКА: Глагол verb_ru не соответствует шаблону! Ввод: [input], проверка выдала [message_list.len].")
-		error("Глагол verb_ru не соответствует шаблону! Ввод: [input], проверка выдала [message_list.len].")
-		return message_list[1]
-	return "[gender_ru(verb_user, message_list[1], message_list[2], message_list[3], message_list[4], message_list[5])][message_list[6]]"
-
-// Basically a quick mechanical interaction message constructor for a multitude of usages. Also helps eliminate human errors in localization.
-/proc/interact_ru(atom/user, var/use_verb, atom/target, var/case_target = ACASE, var/case_user = NCASE, var/secondary=null, var/force_mode="normal")
-	if(target) return "[cap_ru(user, case_user)] [verb_ru(user, use_verb)] [case_ru(target, case_target, user, secondary, force_mode)]"
-	else return "[cap_ru(user, case_user)] [verb_ru(user, use_verb)]"
-
-// An alias for verb_ru + case_ru; despite the naming, verb_ru is good for adjectives/pronouns too
-// Logically concat_ru is incompatible with self_check in cases_ru and is therefore omitted in this proc to avoid runtiming
-/proc/concat_ru(var/word, atom/object, var/case = NCASE, var/capital = FALSE, var/secondary=null, var/force_mode="normal")
-	if(capital) return "[capitalize(verb_ru(object, word))] [case_ru(object, null, case, secondary, force_mode)]"
-	else return "[verb_ru(object, word)] [case_ru(object, case, null, secondary, force_mode)]"

--- a/russian/_client_cases_ru.dm
+++ b/russian/_client_cases_ru.dm
@@ -29,12 +29,9 @@
 	if(!pref.cases[PCASE]) pref.cases[PCASE] = pref.real_name
 
 /datum/category_item/player_setup_item/general/cases/copy_to_mob(var/mob/living/carbon/human/character)
-	character.cases_ru[NCASE]			= pref.cases[NCASE]
-	character.cases_ru[GCASE]			= pref.cases[GCASE]
-	character.cases_ru[DCASE]			= pref.cases[DCASE]
-	character.cases_ru[ACASE]			= pref.cases[ACASE]
-	character.cases_ru[ICASE]			= pref.cases[ICASE]
-	character.cases_ru[PCASE]			= pref.cases[PCASE]
+	// Bastion of Endeavor TODO: This will need some work after we get a proper case editor
+	character.cases_ru["basic"] = list(RUGENDER = character.gender, NCASE = pref.cases[NCASE], GCASE = pref.cases[GCASE], DCASE = pref.cases[DCASE], ACASE = pref.cases[ACASE], ICASE = pref.cases[ICASE], PCASE = pref.cases[PCASE])
+	character.cases_ru["real_name"] = list(RUGENDER = character.gender, NCASE = pref.cases[NCASE], GCASE = pref.cases[GCASE], DCASE = pref.cases[DCASE], ACASE = pref.cases[ACASE], ICASE = pref.cases[ICASE], PCASE = pref.cases[PCASE])
 
 /datum/category_item/player_setup_item/general/cases/content(var/mob/user)
 	. += "<a href='?src=\ref[src];cases=open'>Установить склонение имени</a><br/>"

--- a/russian/_russian_ru.dm
+++ b/russian/_russian_ru.dm
@@ -6,8 +6,6 @@
 // Cases are needed for proper russian grammar in the game. Added as a list that can be freely expanded.
 // This only seems to work with New(), which is alright but might turn into a mess when used with decls.
 // This list by itself, however, is a helpful way of having all atoms and datums carry all information that is relevant to russian grammar.
-/atom
-	cases_ru = new /list()
 
 /area
 	var/prep_override_ru = FALSE // This allows us to have different prepositions for areas. ON the deck, IN the room, etc.
@@ -15,72 +13,23 @@
 
 // Certain datums need cases too.
 // Reagents want to have cases, but will default to "glass of something".
-/datum/reagent
-	cases_ru = new /list()
+///datum/reagent
+//	cases_ru = new /list()
 
 /datum/reagent/New()
 	..()
-	cases_ru["glass"] = new /list()
-	cases_ru["glass"][RUGENDER] = "male"
-	cases_ru["glass"][NCASE] = "стакан с чем-то"
-	cases_ru["glass"][GCASE] = "стакана с чем-то"
-	cases_ru["glass"][DCASE] = "стакану с чем-то"
-	cases_ru["glass"][ACASE] = "стакан с чем-то"
-	cases_ru["glass"][ICASE] = "стаканом с чем-то"
-	cases_ru["glass"][PCASE] = "стакане с чем-то"
-
-/datum/material
-	var/case_override_ru // Case override handles the order of words in material stacks. By default, Material + Sheet. If set to TRUE, Sheet of Material.
-	var/name_override_ru // Required for other objects made with materials. Glass Table (by default), Table of Reinforced Glass (custom).
-	cases_ru = new /list() // Same as earlier cases.
-
-// Fairly self-explanatory.
-/datum/material/New()
-	..()
-	cases_ru["sheet_singular"] = new /list()
-	cases_ru["sheet_singular"][RUGENDER] = "male"
-	cases_ru["sheet_singular"][NCASE] = "лист"
-	cases_ru["sheet_singular"][GCASE] = "листа"
-	cases_ru["sheet_singular"][DCASE] = "листу"
-	cases_ru["sheet_singular"][ACASE] = "лист"
-	cases_ru["sheet_singular"][ICASE] = "листом"
-	cases_ru["sheet_singular"][PCASE] = "листе"
-	cases_ru["sheet_plural"] = new /list()
-	cases_ru["sheet_plural"][RUGENDER] = "plural"
-	cases_ru["sheet_plural"][NCASE] = "листы"
-	cases_ru["sheet_plural"][GCASE] = "листов"
-	cases_ru["sheet_plural"][DCASE] = "листам"
-	cases_ru["sheet_plural"][ACASE] = "листы"
-	cases_ru["sheet_plural"][ICASE] = "листами"
-	cases_ru["sheet_plural"][PCASE] = "листах"
+	case_blueprint_ru += "муж#стакан;n1a с чем-то#glass"
 
 /obj/item/weapon/reagent_containers/food/snacks
 	var/foodtype_ru // Handles the appropriate verb for various types of meals.
 
 /obj/effect/decal/cleanable/blood/New()
 	..()
-	cases_ru["dry"] = new /list()
-	cases_ru["dry"][RUGENDER] = "female"
-	cases_ru["dry"][NCASE] = "засохшая кровь"
-	cases_ru["dry"][GCASE] = "засохшей крови"
-	cases_ru["dry"][DCASE] = "засохшей крови"
-	cases_ru["dry"][ACASE] = "засохшую кровь"
-	cases_ru["dry"][ICASE] = "засохшей кровью"
-	cases_ru["dry"][PCASE] = "засохшей крови"
+	case_blueprint_ru += "жен#засохш;adj4aX кро;n8e#dry"
 
 // Work in progress, but it is likely that seeds are going to need this.
 /datum/seed
 	cases_ru = new /list()
-
-/datum/seed/New()
-	..()
-	cases_ru[RUGENDER] = "male"
-	cases_ru[NCASE] = "пакетик семян"
-	cases_ru[GCASE] = "пакетика семян"
-	cases_ru[DCASE] = "пакетику семян"
-	cases_ru[ACASE] = "пакетик семян"
-	cases_ru[ICASE] = "пакетиком семян"
-	cases_ru[PCASE] = "пакетике семян"
 
 /decl/flooring
 	cases_ru = new /list()
@@ -98,16 +47,10 @@
 	var/supply_pack_name_ru // This is likely to only ever be under the genitive case!
 
 // Should the worst happen and the need to override the template arises, all of this should be safe to override with New().
+// Bastion of Endeavor TODO: No idea if this breaks things or not but come back to this when localizing cargo
 /datum/supply_pack/New()
 	..()
-	cases_ru["containername"] = new /list()
-	cases_ru["containername"][RUGENDER] = "male"
-	cases_ru["containername"][NCASE] = "ящик от [supply_pack_name_ru]"
-	cases_ru["containername"][GCASE] = "ящика от [supply_pack_name_ru]"
-	cases_ru["containername"][DCASE] = "ящику от [supply_pack_name_ru]"
-	cases_ru["containername"][ACASE] = "ящик от [supply_pack_name_ru]"
-	cases_ru["containername"][ICASE] = "ящиком от [supply_pack_name_ru]"
-	cases_ru["containername"][PCASE] = "ящике от [supply_pack_name_ru]"
+	case_blueprint_ru += "муж#ящик;n3a от [supply_pack_name_ru]#containername"
 	containername = "Ящик от [supply_pack_name_ru]"
 
 // This proc handles the appropriate numeral word depending on the, well, number.
@@ -131,37 +74,22 @@
 	if (b == 1) return "[output][endings_list[2]]"
 	return "[output][endings_list[4]]"
 
-// Backs up cases before changing them.
-/atom/proc/storecase_ru(atom/input)
-	input.cases_ru["initial"] = deepCopyList(input.cases_ru)
-	return
-
-// Adds something to the end of all cases of an atom, as well as changes its rugender element.
-/atom/proc/appendcase_ru(atom/input, content)
-	storecase_ru(input)
-	for(var/case in input.cases_ru)
-		if(case == RUGENDER) input.cases_ru[case] = input.cases_ru["initial"][case]
-		input.cases_ru[case] += content
-	return
-
-// Reverts the grammar cases of an atom to their backed up state.
-/atom/proc/restorecase_ru(atom/input)
-	input.cases_ru = deepCopyList(input.cases_ru["initial"])
-	return
-
-// In theory, this should be able to quickly set up the cases for things without having to copypaste the code for cases lists.
-// It looks a little ugly, since its a lazy way of only assigning the essential cases.
-/datum/proc/assigncases_ru(var/list/cases)
-	cases_ru = deepCopyList(cases)
-	return
-
 // Dispenses an appropriately formatted string depending on the material and what it's used on.
+/* Commented out until materials are localized, the proc needs adjustments after the refactor but the basic idea is there.
+/datum/material
+	var/case_override_ru // Case override handles the order of words in material stacks. By default, Material + Sheet. If set to TRUE, Sheet of Material.
+	var/name_override_ru // Required for other objects made with materials. Glass Table (by default), Table of Reinforced Glass (custom).
+
+/datum/material/New()
+	case_blueprint_ru += "муж#лист;n1b#sheet"
+
 /proc/matadj_ru(datum/material, case = "case", gender = "gender", input = "", pre = " из ")
 	var/datum/material/mat = material
 	var/adjective = ""
 	adjective = mat.cases_ru["adj_[gender]"][case]
 	if(mat.name_override_ru) return "[input][pre]" + mat.cases_ru["display_name"][GCASE]
 	else return "[adjective][(input)? " [input]" : ""]"
+*/
 
 // The following proc adjusts a preposition to be used before a word. The list of consonants is provided for this very cause.
 var/global/list/consonants_ru = list("б", "в", "г", "д", "ж", "з", "й", "к", "л", "м", "н", "п", "р", "с", "т", "ф", "х", "ц", "ч", "ш", "щ")
@@ -194,11 +122,11 @@ var/global/list/consonants_ru = list("б", "в", "г", "д", "ж", "з", "й", "
 			return "[is_capital? "[capitalize(preposition)]" : "[preposition]"]"
 
 // Basically a better prep_ru
-/proc/prep_adv_ru(var/preposition = "", atom/input, var/case = "gcase")
+/proc/prep_adv_ru(var/preposition = "", atom/input, var/case = GCASE)
 	return "[prep_ru(input, preposition)] [case_ru(input, case)]"
 
 // This is a simple proc that adds an apropriate ending to a verb depending on the user's gender. This is core.
-/proc/gender_ru(input, base_verb = "", he_end = "", she_end = "а", it_end = "о", they_end = "и")
+/proc/gender_ru(input, base_verb = "", he_end = "", she_end = "а", it_end = "о", they_end = "и", index="basic")
 	var/gender_key = "male"
 	if(istype(input, /mob/living/carbon/human))
 		var/mob/user = input
@@ -206,24 +134,33 @@ var/global/list/consonants_ru = list("б", "в", "г", "д", "ж", "з", "й", "
 		gender_key = user_gender.key
 	else if (istype(input, /atom))
 		var/atom/A = input
-		gender_key = A.cases_ru[RUGENDER]
+		gender_key = A.cases_ru[index][RUGENDER]
 	switch(lowertext(gender_key))
 		if("male") return "[base_verb][he_end]"
-		if("мужской") return "[base_verb][he_end]" // forgot what these were needed for but oh well
 		if("female") return "[base_verb][she_end]"
-		if("женский") return "[base_verb][she_end]"
 		if("neuter") return "[base_verb][it_end]"
-		if("средний") return "[base_verb][it_end]"
 		if("plural") return "[base_verb][they_end]"
-		if("множественное число") return "[base_verb][they_end]"
 	return "[base_verb][he_end]"
 
 // An updated version of gender_ru that helps handle hardcoded messages, e.g. arrivals/cryo announcements and attack verbs.
-// Input template: "base/m_ending/f_ending/n_ending/p_ending/extra_text/case". Case defines the target's case, or hides target if unspecified.
-/proc/verb_adv_ru(var/atom/verb_user, var/input, var/atom/target)
+// Largely a copypaste of verb_adv_ru with the target removed. Meant to be used in the procs below.
+/proc/verb_ru(var/atom/verb_user, var/input, var/index_v = "basic")
 	var/list/message_list = splittext_char(input, ";")
 	if(message_list.len == 1)
-		return "[gender_ru(verb_user, input)]" // If the template is omitted, use the default verb endings.
+		return "[gender_ru(verb_user, input, index = index_v)]" // If the template is omitted, use the default verb endings.
+	if(message_list.len < 5)
+		log_grammar_ru("ОШИБКА: Глагол verb_ru не соответствует шаблону! Ввод: [input], проверка выдала [message_list.len].")
+		error("Глагол verb_ru не соответствует шаблону! Ввод: [input], проверка выдала [message_list.len].")
+		return message_list[1]
+	return "[gender_ru(verb_user, message_list[1], message_list[2], message_list[3], message_list[4], message_list[5], index_v)][message_list[6]]"
+
+// Input template: "base/m_ending/f_ending/n_ending/p_ending/extra_text/case". Case defines the target's case, or hides target if unspecified.
+// Bastion of Endeavor TODO: This whole proc might be redundant be we won't know for sure until we get to living defense localization
+/*
+/proc/verb_adv_ru(var/atom/verb_user, var/input, var/atom/target, var/index_v)
+	var/list/message_list = splittext_char(input, ";")
+	if(message_list.len == 1)
+		return "[gender_ru(verb_user, input, index = index_v)]" // If the template is omitted, use the default verb endings.
 	if(message_list.len < 6)
 		log_grammar_ru("ОШИБКА: Глагол verb_adv_ru не соответствует шаблону! Ввод: [input], проверка выдала [message_list.len].")
 		error("Глагол verb_adv_ru не соответствует шаблону! Ввод: [input], проверка выдала [message_list.len].")
@@ -231,21 +168,21 @@ var/global/list/consonants_ru = list("б", "в", "г", "д", "ж", "з", "й", "
 	var/who = message_list[7] // these few lines might be redundant thanks to interact_ru but who knows
 	if (findtext_char(input, "case"))
 		who = case_ru(target, message_list[7])
-	return "[gender_ru(verb_user, message_list[1], message_list[2], message_list[3], message_list[4], message_list[5])][who? " [who] " : ""][message_list[6]]"
-
-// It looks silly, but it's very important for attack verbs that need custom cases that can't be provided with case_ru.
-// Actually this entire thing is just ancient code at this point and will need a rework with mob localization.
-/proc/attack_prep_ru(var/att_prep, var/att_case, var/ncase, var/gcase, var/dcase, var/acase, var/icase, var/pcase, var/obj/target)
-	if(target)
-		return "[prep_ru(target, att_prep)] [case_ru(target, att_case)]"
-	if(att_case == NCASE) return "[att_prep] [ncase]"
-	if(att_case == GCASE) return "[att_prep] [gcase]"
-	if(att_case == DCASE) return "[att_prep] [dcase]"
-	if(att_case == ACASE) return "[att_prep] [acase]"
-	if(att_case == ICASE) return "[att_prep] [icase]"
-	if(att_case == PCASE) return "[att_prep] [pcase]"
+	return "[gender_ru(verb_user, message_list[1], message_list[2], message_list[3], message_list[4], message_list[5], index_v)][who? " [who] " : ""][message_list[6]]"
+*/
 
 // Handles the prep_override_ru var.
 /proc/area_name_ru(var/area/input)
 	if(!input.prep_override_ru) return "[prep_adv_ru(input, "в", PCASE)]"
 	else return "на [pcase_ru(input)]"
+
+// Basically a quick mechanical interaction message constructor for a multitude of usages. Also helps eliminate human errors in localization.
+/proc/interact_ru(atom/user, var/use_verb, atom/target, var/case_target = ACASE, var/case_user = NCASE, var/secondary=null, var/force_mode="normal")
+	if(target) return "[cap_ru(user, case_user)] [verb_ru(user, use_verb)] [case_ru(target, case_target, user, secondary, force_mode)]"
+	else return "[cap_ru(user, case_user)] [verb_ru(user, use_verb)]"
+
+// An alias for verb_ru + case_ru; despite the naming, verb_ru is good for adjectives/pronouns too
+// Logically concat_ru is incompatible with self_check in cases_ru and is therefore omitted in this proc to avoid runtiming
+/proc/concat_ru(var/word, atom/object, var/case = NCASE, var/capital = FALSE, var/secondary=null, var/force_mode="normal")
+	if(capital) return "[capitalize(verb_ru(object, word))] [case_ru(object, null, case, secondary, force_mode)]"
+	else return "[verb_ru(object, word)] [case_ru(object, case, null, secondary, force_mode)]"

--- a/russian/_verbs_ru.dm
+++ b/russian/_verbs_ru.dm
@@ -18,35 +18,32 @@
 		chosen = tgui_input_list(usr, "Выберите необходимый атом:", "Проверка падежей", matches)
 		if(!chosen)
 			return
-	if(ispath(chosen,/turf))
-		var/turf/T = get_turf(usr.loc)
-		T.ChangeTurf(chosen)
-	else
-		var/atom/spawned = new chosen(usr.loc)
-		var/msg = "<meta charset=\"UTF-8\">Падежи [chosen]:<HR>"
-		msg += "<br>Шаблоны: [spawned.case_blueprint_ru.Join("<br>")]"
-		if (spawned.always_plural_ru)
-			msg += "<br>Этот атом используется в основном во множественном числе."
-		if (spawned.number_lock_ru)
-			if (spawned.number_lock_ru == "singular")
-				msg += "<br>Этот атом склоняется ТОЛЬКО в единственном числе:"
-			if (spawned.number_lock_ru == "plural")
-				msg += "<br>Этот атом склоняется ТОЛЬКО во множественном числе:"
-			msg += "<br>force_mode = \"normal\": [case_ru(spawned, NCASE)]"
-			msg += "<br>force_mode = \"singular\": [case_ru(spawned, NCASE, force_mode = "singular")]"
-			msg += "<br>force_mode = \"plural\": [case_ru(spawned, NCASE, force_mode = "plural")]"
-		for (var/case in spawned.cases_ru)
+	var/atom/spawned = new chosen(usr.loc)
+	var/msg = "<meta charset=\"UTF-8\">Падежи [chosen]:<HR>"
+	msg += "<br>Шаблоны: [spawned.case_blueprint_ru.Join("<br>")]"
+	if (spawned.always_plural_ru)
+		msg += "<br>Этот атом используется в основном во множественном числе."
+	if (spawned.number_lock_ru)
+		if (spawned.number_lock_ru == "singular")
+			msg += "<br>Этот атом склоняется ТОЛЬКО в единственном числе:"
+		if (spawned.number_lock_ru == "plural")
+			msg += "<br>Этот атом склоняется ТОЛЬКО во множественном числе:"
+		msg += "<br>force_mode = \"normal\": [case_ru(spawned, NCASE)]"
+		msg += "<br>force_mode = \"singular\": [case_ru(spawned, NCASE, force_mode = "singular")]"
+		msg += "<br>force_mode = \"plural\": [case_ru(spawned, NCASE, force_mode = "plural")]"
+	for(var/case_group in spawned.cases_ru)	
+		for (var/case in spawned.cases_ru[case_group])
 			if(case == RUGENDER)
-				msg += "<br>Род: [spawned.cases_ru[case]]"
+				msg += "<br>Род: [spawned.cases_ru[case_group][case]]"
 				continue
 			else if (case == PLURAL_RUGENDER)
 				continue
-			msg += "<br>[make_case_fancy_ru(case)]: [spawned.cases_ru[case]]"
-		src << browse(msg,"window=src.type")
-		vv_update_display(spawned, "deleted", VV_MSG_DELETED)
-		qdel(spawned)
-		if(!QDELETED(spawned))
-			vv_update_display(spawned, "deleted", "")
+			msg += "<br>[make_case_fancy_ru(case)]: [spawned.cases_ru[case_group][case]]"
+	src << browse(msg,"window=debug_cases_item")
+	vv_update_display(spawned, "deleted", VV_MSG_DELETED)
+	qdel(spawned)
+	if(!QDELETED(spawned))
+		vv_update_display(spawned, "deleted", "")
 
 /client/add_admin_verbs()
 	if(holder)
@@ -70,7 +67,7 @@
 		dat += "<tr><td>[item]</td>" // имя
 		dat += "<td>[item.type]</td>" // тип
 		dat += "<td>[item.case_blueprint_ru? item.case_blueprint_ru[1] : "<b><span style='color: red;'>НЕТ</span></b>"]</td>" // шаблон
-		dat += "<td>[item.cases_ru["rugender"]? item.cases_ru["rugender"] : "Нет"]</td>"
+		dat += "<td>[case_ru(item, RUGENDER)? case_ru(item, RUGENDER) : "Нет"]</td>"
 		dat += "<td>[ncase_ru(item)]</td>" // и.п
 		dat += "<td>[gcase_ru(item)]</td>" // р.п
 		dat += "<td>[dcase_ru(item)]</td>" // д.п
@@ -81,4 +78,4 @@
 		dat += "<td>[item.always_plural_ru? always_plural_ru : "Нет"]</td></tr>" // мн. ч
 		qdel(item)
 	dat += "</table></body></html>"
-	src << browse(dat,"window=src.type")
+	src << browse(dat,"window=debug_cases_mass")


### PR DESCRIPTION
- Все основные падежи теперь складываются в подлист под индексом basic
- Введено логирование системы падежей на случай экстренной необходимости (выключено по умолчанию)
- Вышеупомянутое логирование также теперь маленько доработано чтобы учитывать листы в листах
- Мобы игроков теперь дублируют свои падежи из редактора в подлист real_name (это пригодится позже)
- Удалены/закомменчены устаревшие проки, новые маленько перераскиданы по файлам
- Куча мелких правок в логике грамматических проков
- Исправлена ошибка, при которой на раундстарте при наличии Менеджера объекта отображалось сообщение о том, что его нет