### PR TITLE
Фиксит иконки VChat

### DIFF
--- a/russian/_cases_ru.dm
+++ b/russian/_cases_ru.dm
@@ -16,8 +16,8 @@ var/global/list/self_cases_list_ru = list(
 	ICASE = "собой", \
 	PCASE = "себе")
 /datum
-	var/list/case_blueprint_ru = list()
-	var/list/cases_ru = list()
+	var/list/case_blueprint_ru
+	var/list/cases_ru
 	var/number_lock_ru
 	var/always_plural_ru
 


### PR DESCRIPTION
По всей видимости, они пропали после рефактора падежей в подлисты, поэтому я возвращаю их на место, и заодно (наверное) что-то сломаю в другом месте.
Бьонд рулит!