### PR TITLE
[VR]  Tweaks the server config button for whether simple mobs and robots spawn with self-recolour to be all-staff from admin-only

### DIFF
--- a/code/modules/admin/admin_verb_lists_vr.dm
+++ b/code/modules/admin/admin_verb_lists_vr.dm
@@ -131,7 +131,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/make_mentor,
 	/client/proc/unmake_mentor,
 	/client/proc/removetickets,
-	/client/proc/delbook
+	/client/proc/delbook,
+	/client/proc/toggle_spawning_with_recolour
 	)
 
 var/list/admin_verbs_ban = list(
@@ -224,8 +225,7 @@ var/list/admin_verbs_server = list(
 	/client/proc/recipe_dump,
 	/client/proc/panicbunker,
 	/client/proc/paranoia_logging,
-	/client/proc/ip_reputation,
-	/client/proc/toggle_spawning_with_recolour
+	/client/proc/ip_reputation
 	)
 
 var/list/admin_verbs_debug = list(
@@ -567,6 +567,7 @@ var/list/admin_verbs_event_manager = list(
 	/client/proc/cmd_debug_del_all,
 	/client/proc/toggle_random_events,
 	/client/proc/modify_server_news,
+	/client/proc/toggle_spawning_with_recolour,
 	/datum/admins/proc/quick_nif, //CHOMPStation Add,
 	/datum/admins/proc/quick_authentic_nif //CHOMPStation add
 

--- a/code/modules/admin/admin_verbs_vr.dm
+++ b/code/modules/admin/admin_verbs_vr.dm
@@ -127,7 +127,7 @@
 	set desc = "Makes it so new robots/simple_mobs spawn with a verb to recolour themselves for this round. You must set them separately."
 	set category = "Server"
 
-	if(!check_rights(R_SERVER))
+	if(!check_rights(R_ADMIN|R_EVENT|R_FUN))
 		return
 
 	var/which = tgui_alert(usr, "Which do you want to toggle?", "Choose Recolour Toggle", list("Robot", "Simple Mob"))


### PR DESCRIPTION
Исходный ПР: 8100