### PR TITLE
[CH] fix ooc notes not properly transferring on proteans

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/protean/protean_blob.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/protean/protean_blob.dm
@@ -487,6 +487,11 @@
 		//Put our owner in it (don't transfer var/mind)
 		blob.ckey = ckey
 		blob.ooc_notes = ooc_notes
+		blob.ooc_notes_likes = ooc_notes_likes
+		blob.ooc_notes_dislikes = ooc_notes_dislikes
+		blob.ooc_notes_favs = ooc_notes_favs
+		blob.ooc_notes_maybes = ooc_notes_maybes
+		blob.ooc_notes_style = ooc_notes_style
 		temporary_form = blob
 		var/obj/item/radio/R = null
 		if(isradio(l_ear))
@@ -614,6 +619,11 @@
 		//Put our owner in it (don't transfer var/mind)
 		ckey = blob.ckey
 		ooc_notes = blob.ooc_notes // Lets give the protean any updated notes from blob form.
+		ooc_notes_likes = blob.ooc_notes_likes
+		ooc_notes_dislikes = blob.ooc_notes_dislikes
+		ooc_notes_favs = blob.ooc_notes_favs
+		ooc_notes_maybes = blob.ooc_notes_maybes
+		ooc_notes_style = blob.ooc_notes_style
 		temporary_form = null
 
 		//Transfer vore organs


### PR DESCRIPTION
Исходный ПР: 9392

🆑
fix: Исправлено сохранение Примечаний OOC персонажей расы Многоликий при переключении между обличиями.
/:cl: