### PR TITLE
[VR]  Water Cooler Tweaks

### DIFF
--- a/code/modules/reagents/machinery/dispenser/reagent_tank.dm
+++ b/code/modules/reagents/machinery/dispenser/reagent_tank.dm
@@ -340,7 +340,7 @@
 /obj/structure/reagent_dispensers/water_cooler/Initialize()
 	. = ..()
 	if(bottle)
-		reagents.add_reagent("water",120)
+		reagents.add_reagent("water",2000)
 	update_icon()
 
 /obj/structure/reagent_dispensers/water_cooler/examine(mob/user)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -422,11 +422,18 @@
 	name = "water-cooler bottle"
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "water_cooler_bottle"
-	matter = list(MAT_GLASS = 2000)
-	w_class = ITEMSIZE_NORMAL
+	matter = list(MAT_PLASTIC = 2000)
+	w_class = ITEMSIZE_NO_CONTAINER
 	amount_per_transfer_from_this = 20
 	possible_transfer_amounts = list(10,20,30,60,120)
-	volume = 120
+	volume = 2000
+	slowdown = 2
+
+	can_be_placed_into = list(
+		/obj/structure/table,
+		/obj/structure/closet,
+		/obj/structure/sink
+		)
 
 /obj/item/reagent_containers/glass/pint_mug
 	desc = "A rustic pint mug designed for drinking ale."


### PR DESCRIPTION
Исходный ПР: 9384

🆑
tweak: Количество воды в кулерах повышено с 60 до 2000. Бутылки кулеров больше нельзя помещать в сумки, а также они замедляют персонажа при переноске.
/:cl: