### PR TITLE
[VR]  Allow pouring stuff into tanks

### DIFF
--- a/code/modules/reagents/machinery/dispenser/reagent_tank.dm
+++ b/code/modules/reagents/machinery/dispenser/reagent_tank.dm
@@ -1,6 +1,7 @@
 /obj/structure/reagent_dispensers
 	name = "Dispenser"
 	desc = "..."
+	description_info = "The input can be opened by Alt-clicking it, allowing you to pour reagents inside."
 	icon = 'icons/obj/chemical_tanks.dmi'
 	icon_state = "tank"
 	layer = TABLE_LAYER
@@ -15,6 +16,8 @@
 
 	var/amount_per_transfer_from_this = 10
 	var/possible_transfer_amounts = list(10,25,50,100)
+
+	var/open_top = FALSE
 
 /obj/structure/reagent_dispensers/attackby(obj/item/W as obj, mob/user as mob)
 	return
@@ -78,6 +81,19 @@
 
 /obj/structure/reagent_dispensers/blob_act()
 	qdel(src)
+
+/obj/structure/reagent_dispensers/AltClick(mob/user)
+	if(!Adjacent(user))
+		return
+
+	if(flags & OPENCONTAINER)
+		to_chat(user, span_notice("You close the input on \the [src]"))
+		flags -= OPENCONTAINER
+		open_top = FALSE
+	else
+		to_chat(user, span_notice("You open the input on \the [src], allowing you to pour reagents in."))
+		flags |= OPENCONTAINER
+		open_top = TRUE
 
 /*
  * Tanks

--- a/code/modules/reagents/reagent_containers/_reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers/_reagent_containers.dm
@@ -48,6 +48,9 @@
 	if(!istype(target))
 		return 0
 
+	if(target.open_top)
+		return 0
+
 	if(!target.reagents || !target.reagents.total_volume)
 		// to_chat(user, span_notice("[target] is empty."))
 		balloon_alert(user, "[target] is empty.") // CHOMPEdit - Changed to balloon alert


### PR DESCRIPTION
Исходный ПР: 9459

:cl:
:qol: Альт+ЛКМ теперь позволяет открыть любой раздатчик веществ (например бак воды или топлива), чтобы влить в него жидкость из ведра/мензурки и т.п.
/:cl: