### PR TITLE
[VR]  Add Engineering Drake to plushies crate

### DIFF
--- a/code/datums/supplypacks/misc.dm
+++ b/code/datums/supplypacks/misc.dm
@@ -80,6 +80,7 @@
 			/obj/item/toy/plushie/slimeplushie,
 			/obj/item/toy/plushie/box,
 			/obj/item/toy/plushie/borgplushie,
+			/obj/item/toy/plushie/borgplushie/drake/eng,
 			/obj/item/toy/plushie/borgplushie/medihound,
 			/obj/item/toy/plushie/borgplushie/scrubpuppy,
 			/obj/item/toy/plushie/foxbear,


### PR DESCRIPTION
Исходный ПР: 9496

🆑
tweak: Плюшевая игрушка инженерного борга-дракона теперь может быть найдена в ящике случайных плюшевых игрушек грузового отдела.
/:cl: