### PR TITLE
[VR]  Climbing/Swimming Trait Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -242,6 +242,9 @@
 	var/can_space_freemove = FALSE							// Can we freely move in space?
 	var/can_zero_g_move	= FALSE								// What about just in zero-g non-space?
 
+	var/swim_mult = 1										//multiplier to our z-movement rate for swimming
+	var/climb_mult = 1										//multiplier to our z-movement rate for lattices/catwalks
+
 	var/item_slowdown_mod = 1								// How affected by item slowdown the species is.
 	var/primitive_form										// Lesser form, if any (ie. monkey for humans)
 	var/greater_form										// Greater form, if any, ie. human for monkeys.

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -267,6 +267,8 @@
 	reagent_tag = IS_TAJARA
 	allergens = ALLERGEN_STIMULANT
 
+	climb_mult = 0.75
+
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/paw
 
 	heat_discomfort_level = 292

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -398,6 +398,8 @@
 	silk_reserve = 500
 	silk_max_reserve = 1000
 
+	climb_mult = 0.75
+
 /datum/species/spider/handle_environment_special(var/mob/living/carbon/human/H)
 	if(H.stat == DEAD) // If they're dead they won't need anything.
 		return

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -119,6 +119,7 @@
 
 	water_breather = TRUE
 	water_movement = -4 //Negates shallow. Halves deep.
+	swim_mult = 0.5
 
 	flesh_color = "#AFA59E"
 	base_color = "#777777"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -191,7 +191,9 @@
 
 /datum/trait/negative/bad_swimmer
 	name = "Bad Swimmer"
-	desc = "You can't swim very well, all water slows you down a lot and you drown in deep water."
+	desc = "You can't swim very well, all water slows you down a lot and you drown in deep water. You also swim up and down 25% slower."
 	cost = -1
 	custom_only = FALSE
-	var_changes = list("bad_swimmer" = 1, "water_movement" = 4)
+	var_changes = list("bad_swimmer" = 1, "water_movement" = 4, "swim_mult" = 1.25)
+	varchange_type = TRAIT_VARCHANGE_LESS_BETTER
+	excludes = list(/datum/trait/positive/good_swimmer)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -258,12 +258,9 @@
 	cost = 1
 	var_changes = list("throwforce_absorb_threshold" = 10)
 
-
-
-
 /datum/trait/positive/wall_climber
 	name = "Climber, Amateur"
-	desc = "You can climb certain walls without tools! This is likely a personal skill you developed."
+	desc = "You can climb certain walls without tools! This is likely a personal skill you developed. You can also climb lattices and ladders a little bit faster than everyone else."
 	tutorial = "You must approach a wall and right click it and select the \
 	'climb wall' verb to climb it. You suffer from a movement delay of 1.5 with this trait.\n \
 	Your total climb time is expected to be 17.5 seconds. Tools may reduce this. \n\n \
@@ -272,12 +269,12 @@
 	cost = 1
 	custom_only = FALSE
 	banned_species = list(SPECIES_TAJ, SPECIES_VASILISSAN)	// They got unique climbing delay.
-	var_changes = list("can_climb" = TRUE)
+	var_changes = list("can_climb" = TRUE, "climb_mult" = 0.75)
 	excludes = list(/datum/trait/positive/wall_climber_pro, /datum/trait/positive/wall_climber_natural)
 
 /datum/trait/positive/wall_climber_natural
 	name = "Climber, Natural"
-	desc = "You can climb certain walls without tools! This is likely due to the unique anatomy of your species. CUSTOM AND XENOCHIM ONLY"
+	desc = "You can climb certain walls without tools! This is likely due to the unique anatomy of your species. You can climb lattices and ladders slightly faster than everyone else. CUSTOM AND XENOCHIM ONLY"
 	tutorial = "You must approach a wall and right click it and select the \
 	'climb wall' verb to climb it. You suffer from a movement delay of 1.5 with this trait.\n \
 	Your total climb time is expected to be 17.5 seconds. Tools may reduce this. \n\n \
@@ -285,13 +282,13 @@
 	a climbable wall. To climbe like so, use the verb 'Climb Down Wall' in IC tab!"
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("can_climb" = TRUE)
+	var_changes = list("can_climb" = TRUE, "climb_mult" = 0.75)
 	allowed_species = list(SPECIES_XENOCHIMERA, SPECIES_CUSTOM)	//So that we avoid needless bloat for xenochim
 	excludes = list(/datum/trait/positive/wall_climber_pro, /datum/trait/positive/wall_climber)
 
 /datum/trait/positive/wall_climber_pro
 	name = "Climber, Professional"
-	desc = "You can climb certain walls without tools! You are a professional rock climber at this, letting you climb almost twice as fast!"
+	desc = "You can climb certain walls without tools! You are a professional rock climber at this, letting you climb almost twice as fast! You can also climb lattices and ladders a fair bit faster than everyone else!"
 	tutorial = "You must approach a wall and right click it and select the \
 	'climb wall' verb to climb it. Your movement delay is just 1.25 with this trait.\n \
 	Your climb time is expected to be 9 seconds. Tools may reduce this. \n\n \
@@ -299,7 +296,7 @@
 	a climbable wall. To climbe like so, use the verb 'Climb Down Wall' in IC tab!"
 	cost = 2
 	custom_only = FALSE
-	var_changes = list("climbing_delay" = 1.25)
+	var_changes = list("climbing_delay" = 1.25, "climb_mult" = 0.5)
 	varchange_type = TRAIT_VARCHANGE_LESS_BETTER
 	excludes = list(/datum/trait/positive/wall_climber,/datum/trait/positive/wall_climber_natural)
 
@@ -309,3 +306,14 @@
 /datum/trait/positive/wall_climber_pro/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	S.can_climb = TRUE
+
+/datum/trait/positive/good_swimmer
+	name = "Pro Swimmer"
+	desc = "You were top of your group in swimming class! This is of questionable usefulness on most planets, but hey, maybe you'll get to visit a nice beach world someday?"
+	tutorial = "You move faster in water, and can move up and down z-levels faster than other swimmers!"
+	cost = 1
+	custom_only = FALSE
+	var_changes = list("water_movement" = -2, "swim_mult" = 0.5)
+	varchange_type = TRAIT_VARCHANGE_LESS_BETTER
+	excludes = list(/datum/trait/negative/bad_swimmer)
+	banned_species = list(SPECIES_AKULA)	// They already swim better than this

--- a/code/modules/multiz/ladders.dm
+++ b/code/modules/multiz/ladders.dm
@@ -107,7 +107,12 @@
 
 	target_ladder.audible_message(span_notice("You hear something coming [direction] \the [src]"), runemessage = "clank clank")
 
-	if(do_after(M, climb_time, src))
+	var/climb_modifier = 1
+	if(istype(M, /mob/living/carbon/human))
+		var/mob/living/carbon/human/MS = M
+		climb_modifier = MS.species.climb_mult
+
+	if(do_after(M, (climb_time * climb_modifier), src))
 		var/turf/T = get_turf(target_ladder)
 		for(var/atom/A in T)
 			if(!A.CanPass(M, M.loc, 1.5, 0))

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -19,6 +19,13 @@
 		var/obj/mecha/mech = loc
 		return mech.relaymove(src,direction)
 
+	var/swim_modifier = 1
+	var/climb_modifier = 1
+	if(istype(src,/mob/living/carbon/human))
+		var/mob/living/carbon/human/MS = src
+		swim_modifier = MS.species.swim_mult
+		climb_modifier = MS.species.climb_mult
+
 	if(!can_ztravel())
 		to_chat(src, span_warning("You lack means of travel in that direction."))
 		return
@@ -49,7 +56,7 @@
 	if(direction == DOWN)
 		var/turf/simulated/floor/water/deep/ocean/diving/sink = start
 		if(istype(sink) && !destination.density)
-			var/pull_up_time = max(3 SECONDS + (src.movement_delay() * 10), 1)
+			var/pull_up_time = max((3 SECONDS + (src.movement_delay() * 10) * swim_modifier), 1)
 			to_chat(src, span_notice("You start diving underwater..."))
 			src.audible_message(span_notice("[src] begins to dive under the water."), runemessage = "splish splosh")
 			if(do_after(src, pull_up_time))
@@ -75,7 +82,7 @@
 			var/turf/simulated/floor/water/deep/ocean/diving/surface = destination
 
 			if(lattice)
-				var/pull_up_time = max(5 SECONDS + (src.movement_delay() * 10), 1)
+				var/pull_up_time = max((5 SECONDS + (src.movement_delay() * 10) * climb_modifier), 1)
 				to_chat(src, span_notice("You grab \the [lattice] and start pulling yourself upward..."))
 				src.audible_message(span_notice("[src] begins climbing up \the [lattice]."), runemessage = "clank clang")
 				if(do_after(src, pull_up_time))
@@ -85,7 +92,7 @@
 					return 0
 
 			else if(istype(surface))
-				var/pull_up_time = max(5 SECONDS + (src.movement_delay() * 10), 1)
+				var/pull_up_time = max((5 SECONDS + (src.movement_delay() * 10) * swim_modifier), 1)
 				to_chat(src, span_notice("You start swimming upwards..."))
 				src.audible_message(span_notice("[src] begins to swim towards the surface."), runemessage = "splish splosh")
 				if(do_after(src, pull_up_time))
@@ -95,7 +102,7 @@
 					return 0
 
 			else if(catwalk?.hatch_open)
-				var/pull_up_time = max(5 SECONDS + (src.movement_delay() * 10), 1)
+				var/pull_up_time = max((5 SECONDS + (src.movement_delay() * 10) * climb_modifier), 1)
 				to_chat(src, span_notice("You grab the edge of \the [catwalk] and start pulling yourself upward..."))
 				var/old_dest = destination
 				destination = get_step(destination, dir) // mob's dir


### PR DESCRIPTION
Исходный ПР: 9488

🆑
tweak: Черты Скалолаз и Пловец теперь дополнительно влияют на скорость передвижения между Z-уровнями.
rscadd: Добавлена черта "Пловец-профессионал", увеличивающая скорость передвижения в воде в любом направлении.
tweak: Акулы теперь перемещаются между Z-уровнями в воде на 50% быстрее.
tweak: Таджары и василиссаны теперь на 25% быстрее взбираются по лестницам и уступам.
/:cl: