### PR TITLE
[CH] Tweaks min account age for heads to 31 days

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -19,7 +19,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	req_admin_notify = 1
 	access = list() 			//See get_access()
 	minimal_access = list() 	//See get_access()
-	minimal_player_age = 31
+	minimal_player_age = 31 //ChompEDIT
 	economic_modifier = 20
 
 	minimum_character_age = 25
@@ -69,7 +69,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	supervisors = "the " + JOB_SITE_MANAGER
 	selection_color = "#1D1D4F"
 	req_admin_notify = 1
-	minimal_player_age = 10
+	minimal_player_age = 31 //ChompEDIT
 	economic_modifier = 10
 
 	minimum_character_age = 25

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -31,7 +31,7 @@
 			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 			            access_heads, access_construction, access_sec_doors,
 			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
-	minimal_player_age = 7
+	minimal_player_age = 31 //ChompEDIT
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/chief_engineer
 	job_description = "The " + JOB_CHIEF_ENGINEER + " manages the Engineering Department, ensuring that the Engineers work on what needs to be done, handling distribution \

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -24,7 +24,7 @@
 
 	minimum_character_age = 25
 	min_age_by_species = list(SPECIES_UNATHI = 70, "mechanical" = 10, SPECIES_HUMAN_VATBORN = 14)
-	minimal_player_age = 10
+	minimal_player_age = 31 //ChompEDIT
 	ideal_character_age = 50
 	ideal_age_by_species = list(SPECIES_UNATHI = 140, "mechanical" = 20, SPECIES_HUMAN_VATBORN = 20)
 	banned_job_species = list(SPECIES_TESHARI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_ZADDAT, "digital")

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -26,7 +26,7 @@
 	alt_titles = list("Research Supervisor")
 
 	minimum_character_age = 25
-	minimal_player_age = 14
+	minimal_player_age = 31 //ChompEDIT
 	min_age_by_species = list(SPECIES_UNATHI = 70, "mechanical" = 10, SPECIES_HUMAN_VATBORN = 14)
 	ideal_character_age = 50
 	ideal_age_by_species = list(SPECIES_UNATHI = 140, "mechanical" = 20, SPECIES_HUMAN_VATBORN = 20)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -25,7 +25,7 @@
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)
 	minimum_character_age = 25
 	min_age_by_species = list(SPECIES_HUMAN_VATBORN = 14)
-	minimal_player_age = 14
+	minimal_player_age = 31 //ChompEDIT
 	ideal_character_age = 50
 	ideal_age_by_species = list(SPECIES_HUMAN_VATBORN = 20)
 	banned_job_species = list(SPECIES_TESHARI, SPECIES_DIONA, SPECIES_PROMETHEAN, SPECIES_ZADDAT, "digital", SPECIES_UNATHI, "mechanical")

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -13,7 +13,7 @@
 	selection_color = "#3F823F"
 	supervisors = "your Laws"
 	req_admin_notify = 1
-	minimal_player_age = 7
+	minimal_player_age = 31 //ChompEDIT
 	account_allowed = 0
 	economic_modifier = 0
 	has_headset = FALSE


### PR DESCRIPTION
Исходный ПР: 9517

🆑
refactor: Минимальный возраст аккаунта игрока для ролей глав отделов теперь составляет 31 день.
/:cl: